### PR TITLE
Add support for parsing 8-digit #rrggbbaa hex colors

### DIFF
--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -145,6 +145,22 @@ impl str::FromStr for Color {
                     b: (iv & 0xff) as u8,
                     a: 1.0,
                 });
+            } else if string_char_count == 9 {
+                let (_, value_string) = string.split_at(1);
+
+                let iv = u64::from_str_radix(value_string, 16)?;
+
+                // (7thSigil) unlike original js code, NaN is impossible
+                if !(iv <= 0xffffffff) {
+                    return Err(ColorParseError);
+                }
+
+                return Ok(Color {
+                    r: ((iv & 0xff000000) >> 24) as u8,
+                    g: ((iv & 0xff0000) >> 16) as u8,
+                    b: ((iv & 0xff00) >> 8) as u8,
+                    a: (((iv & 0xff) as u8) as f32) / 255.,
+                });
             }
 
             return Err(ColorParseError);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -72,6 +72,20 @@ fn abc123() {
                });
 }
 
+
+#[test]
+fn abc123a() {
+    // parse 8-digit #rrggbbaa
+    let c = "#ff0011ff".parse::<Color>().unwrap();
+    assert_eq!(c,
+               Color {
+                   r: 255,
+                   g: 0,
+                   b: 17,
+                   a: 1.0,
+               });
+}
+
 #[test]
 fn named_color() {
     let c = "slateblue".parse::<Color>().unwrap();


### PR DESCRIPTION
As per https://www.w3.org/TR/css-color-4/#hex-notation